### PR TITLE
Potential fix for code scanning alert no. 12: Cross-site scripting

### DIFF
--- a/TextToSpeech.Infra/Services/Ai/NarakeetService.cs
+++ b/TextToSpeech.Infra/Services/Ai/NarakeetService.cs
@@ -2,6 +2,7 @@
 using System.Net.Http.Json;
 using TextToSpeech.Infra.Constants;
 using System.Text.Json;
+using System.Net;
 using System.Text;
 using TextToSpeech.Core.Interfaces;
 using TextToSpeech.Core.Interfaces.Ai;
@@ -142,7 +143,8 @@ public sealed class NarakeetService(IRedisCacheProvider _redisCacheProvider,
 
     private async Task<ReadOnlyMemory<byte>> RequestShortContent(string text, string voice, double speed)
     {
-        StringContent requestBody = new(text, Encoding.UTF8, "text/plain");
+        string sanitizedText = System.Net.WebUtility.HtmlEncode(text);
+        StringContent requestBody = new(sanitizedText, Encoding.UTF8, "text/plain");
 
         _httpClient.DefaultRequestHeaders.Add("accept", "application/octet-stream");
 


### PR DESCRIPTION
Potential fix for [https://github.com/Alikberova/TextToSpeech/security/code-scanning/12](https://github.com/Alikberova/TextToSpeech/security/code-scanning/12)

To fix the issue, the `text` parameter should be sanitized or encoded before being used in the `RequestShortContent` method. The `System.Net.WebUtility.HtmlEncode` method can be used to encode the `text` to ensure that any potentially malicious content is neutralized. This encoding will prevent the input from being interpreted as executable HTML or JavaScript if it is rendered in a web context by the external API.

The fix involves:
1. Modifying the `RequestShortContent` method in `NarakeetService` to encode the `text` parameter using `WebUtility.HtmlEncode`.
2. Adding the necessary `System.Net` namespace import if it is not already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
