### PR TITLE
Handle missing Redis connection gracefully

### DIFF
--- a/TextToSpeech.Api/Extensions/ServicesDiExtension.cs
+++ b/TextToSpeech.Api/Extensions/ServicesDiExtension.cs
@@ -40,7 +40,7 @@ internal static class ServicesDiExtension
         services.AddSingleton<IFileProcessor, TextFileProcessor>();
         services.AddSingleton<IFileProcessor, PdfProcessor>();
         services.AddSingleton<IFileProcessor, EpubProcessor>();
-        services.AddSingleton<IRedisCacheProvider>(new RedisCacheProvider(configuration.GetConnectionString("Redis")!));
+        services.AddSingleton<IRedisCacheProvider>(new RedisCacheProvider(configuration.GetConnectionString("Redis")));
         services.AddSingleton<ITaskManager, TaskManager>();
         services.AddSingleton<IProgressTracker, ProgressTracker>();
         services.AddSingleton<IBackgroundTaskQueue, BackgroundTaskQueue>();

--- a/TextToSpeech.Infra/Services/RedisCacheProvider.cs
+++ b/TextToSpeech.Infra/Services/RedisCacheProvider.cs
@@ -8,8 +8,13 @@ public sealed class RedisCacheProvider : IRedisCacheProvider
 {
     private readonly ConnectionMultiplexer? _redisConnection;
 
-    public RedisCacheProvider(string connectionString)
+    public RedisCacheProvider(string? connectionString)
     {
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            return;
+        }
+
         try
         {
             _redisConnection = ConnectionMultiplexer.Connect(connectionString);

--- a/TextToSpeech.UnitTests/RedisCacheProviderTests.cs
+++ b/TextToSpeech.UnitTests/RedisCacheProviderTests.cs
@@ -1,0 +1,18 @@
+using TextToSpeech.Infra.Services;
+using Xunit;
+
+namespace TextToSpeech.UnitTests;
+
+public class RedisCacheProviderTests
+{
+    [Fact]
+    public async Task HandlesNullConnectionStringGracefully()
+    {
+        var provider = new RedisCacheProvider(null);
+
+        var result = await provider.GetCachedData<string>("missing");
+        Assert.Null(result);
+
+        await provider.SetCachedData("key", "value", TimeSpan.FromSeconds(1));
+    }
+}


### PR DESCRIPTION
## Summary
- avoid throwing when Redis connection string is missing by skipping connection attempt
- register Redis cache provider without null-forcing the connection string
- test that RedisCacheProvider works with a null connection string

## Testing
- `dotnet test TextToSpeech.UnitTests/TextToSpeech.UnitTests.csproj`
- `dotnet test TextToSpeech.IntegrationTests/TextToSpeech.IntegrationTests.csproj` *(fails: Section 'JwtConfig' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f2a80658083219f2fc22c3a9c2a50